### PR TITLE
Define football entities with Sequelize migrations and models

### DIFF
--- a/migrations/20250906164320-create-league.js
+++ b/migrations/20250906164320-create-league.js
@@ -10,13 +10,16 @@ module.exports = {
         type: Sequelize.INTEGER
       },
       name: {
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
+        allowNull: false
       },
       country: {
         type: Sequelize.STRING
       },
       externalRef: {
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
+        allowNull: false,
+        unique: true
       },
       logoUrl: {
         type: Sequelize.STRING

--- a/migrations/20250906164321-create-team.js
+++ b/migrations/20250906164321-create-team.js
@@ -10,10 +10,17 @@ module.exports = {
         type: Sequelize.INTEGER
       },
       leagueId: {
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
+        references: {
+          model: 'Leagues',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL'
       },
       name: {
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
+        allowNull: false
       },
       shortName: {
         type: Sequelize.STRING
@@ -40,7 +47,9 @@ module.exports = {
         type: Sequelize.INTEGER
       },
       externalRef: {
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
+        allowNull: false,
+        unique: true
       },
       description: {
         type: Sequelize.TEXT
@@ -57,6 +66,8 @@ module.exports = {
         type: Sequelize.DATE
       }
     });
+
+    await queryInterface.addIndex('Teams', ['leagueId']);
   },
   async down(queryInterface, Sequelize) {
     await queryInterface.dropTable('Teams');

--- a/migrations/20250906164323-create-player.js
+++ b/migrations/20250906164323-create-player.js
@@ -10,19 +10,23 @@ module.exports = {
         type: Sequelize.INTEGER
       },
       fullName: {
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
+        allowNull: false
       },
       nationality: {
         type: Sequelize.STRING
       },
       primaryPosition: {
-        type: Sequelize.STRING
+        type: Sequelize.ENUM('GK', 'DF', 'MF', 'FW'),
+        allowNull: false
       },
       thumbUrl: {
         type: Sequelize.STRING
       },
       externalRef: {
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
+        allowNull: false,
+        unique: true
       },
       bornAt: {
         type: Sequelize.DATE
@@ -39,5 +43,6 @@ module.exports = {
   },
   async down(queryInterface, Sequelize) {
     await queryInterface.dropTable('Players');
+    await queryInterface.sequelize.query('DROP TYPE IF EXISTS "enum_Players_primaryPosition";');
   }
 };

--- a/migrations/20250906164323-create-stadium-image.js
+++ b/migrations/20250906164323-create-stadium-image.js
@@ -10,16 +10,25 @@ module.exports = {
         type: Sequelize.INTEGER
       },
       teamId: {
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Teams',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
       },
       imageUrl: {
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
+        allowNull: false
       },
       source: {
         type: Sequelize.STRING
       },
       sortOrder: {
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
+        defaultValue: 0
       },
       createdAt: {
         allowNull: false,
@@ -30,6 +39,9 @@ module.exports = {
         type: Sequelize.DATE
       }
     });
+
+    await queryInterface.addIndex('StadiumImages', ['teamId']);
+    await queryInterface.addIndex('StadiumImages', ['teamId', 'sortOrder']);
   },
   async down(queryInterface, Sequelize) {
     await queryInterface.dropTable('StadiumImages');

--- a/migrations/20250906164324-create-squad-membership.js
+++ b/migrations/20250906164324-create-squad-membership.js
@@ -10,22 +10,39 @@ module.exports = {
         type: Sequelize.INTEGER
       },
       teamId: {
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Teams',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
       },
       playerId: {
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Players',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
       },
       season: {
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
+        allowNull: false
       },
       position: {
-        type: Sequelize.STRING
+        type: Sequelize.ENUM('GK', 'DF', 'MF', 'FW'),
+        allowNull: false
       },
       shirtNumber: {
         type: Sequelize.INTEGER
       },
       isCurrent: {
-        type: Sequelize.BOOLEAN
+        type: Sequelize.BOOLEAN,
+        defaultValue: true
       },
       createdAt: {
         allowNull: false,
@@ -36,8 +53,17 @@ module.exports = {
         type: Sequelize.DATE
       }
     });
+
+    await queryInterface.addConstraint('SquadMemberships', {
+      fields: ['teamId', 'playerId', 'season'],
+      type: 'unique',
+      name: 'unique_squadmembership_team_player_season'
+    });
+
+    await queryInterface.addIndex('SquadMemberships', ['teamId', 'season', 'position']);
   },
   async down(queryInterface, Sequelize) {
     await queryInterface.dropTable('SquadMemberships');
+    await queryInterface.sequelize.query('DROP TYPE IF EXISTS "enum_SquadMemberships_position";');
   }
 };

--- a/migrations/20250906164325-create-user.js
+++ b/migrations/20250906164325-create-user.js
@@ -10,7 +10,9 @@ module.exports = {
         type: Sequelize.INTEGER
       },
       email: {
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
+        allowNull: false,
+        unique: true
       },
       passwordHash: {
         type: Sequelize.STRING
@@ -19,7 +21,8 @@ module.exports = {
         type: Sequelize.STRING
       },
       googleSub: {
-        type: Sequelize.STRING
+        type: Sequelize.STRING,
+        unique: true
       },
       createdAt: {
         allowNull: false,

--- a/migrations/20250906164326-create-favorite.js
+++ b/migrations/20250906164326-create-favorite.js
@@ -10,10 +10,24 @@ module.exports = {
         type: Sequelize.INTEGER
       },
       userId: {
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Users',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
       },
       teamId: {
-        type: Sequelize.INTEGER
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: {
+          model: 'Teams',
+          key: 'id'
+        },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE'
       },
       createdAt: {
         allowNull: false,
@@ -24,6 +38,15 @@ module.exports = {
         type: Sequelize.DATE
       }
     });
+
+    await queryInterface.addConstraint('Favorites', {
+      fields: ['userId', 'teamId'],
+      type: 'unique',
+      name: 'unique_favorite_user_team'
+    });
+
+    await queryInterface.addIndex('Favorites', ['userId']);
+    await queryInterface.addIndex('Favorites', ['teamId']);
   },
   async down(queryInterface, Sequelize) {
     await queryInterface.dropTable('Favorites');

--- a/models/favorite.js
+++ b/models/favorite.js
@@ -10,12 +10,31 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-      // define association here
+      Favorite.belongsTo(models.User, { foreignKey: 'userId' });
+      Favorite.belongsTo(models.Team, { foreignKey: 'teamId' });
     }
   }
   Favorite.init({
-    userId: DataTypes.INTEGER,
-    teamId: DataTypes.INTEGER
+    userId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Users',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE'
+    },
+    teamId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Teams',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE'
+    }
   }, {
     sequelize,
     modelName: 'Favorite',

--- a/models/league.js
+++ b/models/league.js
@@ -10,13 +10,20 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-      // define association here
+      League.hasMany(models.Team, { foreignKey: 'leagueId' });
     }
   }
   League.init({
-    name: DataTypes.STRING,
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
     country: DataTypes.STRING,
-    externalRef: DataTypes.STRING,
+    externalRef: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true
+    },
     logoUrl: DataTypes.STRING
   }, {
     sequelize,

--- a/models/player.js
+++ b/models/player.js
@@ -10,15 +10,29 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-      // define association here
+      Player.belongsToMany(models.Team, {
+        through: models.SquadMembership,
+        foreignKey: 'playerId',
+        otherKey: 'teamId'
+      });
     }
   }
   Player.init({
-    fullName: DataTypes.STRING,
+    fullName: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
     nationality: DataTypes.STRING,
-    primaryPosition: DataTypes.STRING,
+    primaryPosition: {
+      type: DataTypes.ENUM('GK', 'DF', 'MF', 'FW'),
+      allowNull: false
+    },
     thumbUrl: DataTypes.STRING,
-    externalRef: DataTypes.STRING,
+    externalRef: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true
+    },
     bornAt: DataTypes.DATE
   }, {
     sequelize,

--- a/models/squadmembership.js
+++ b/models/squadmembership.js
@@ -10,16 +10,44 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-      // define association here
+      SquadMembership.belongsTo(models.Team, { foreignKey: 'teamId' });
+      SquadMembership.belongsTo(models.Player, { foreignKey: 'playerId' });
     }
   }
   SquadMembership.init({
-    teamId: DataTypes.INTEGER,
-    playerId: DataTypes.INTEGER,
-    season: DataTypes.STRING,
-    position: DataTypes.STRING,
+    teamId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Teams',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE'
+    },
+    playerId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Players',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE'
+    },
+    season: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    position: {
+      type: DataTypes.ENUM('GK', 'DF', 'MF', 'FW'),
+      allowNull: false
+    },
     shirtNumber: DataTypes.INTEGER,
-    isCurrent: DataTypes.BOOLEAN
+    isCurrent: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: true
+    }
   }, {
     sequelize,
     modelName: 'SquadMembership',

--- a/models/stadiumimage.js
+++ b/models/stadiumimage.js
@@ -10,14 +10,29 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-      // define association here
+      StadiumImage.belongsTo(models.Team, { foreignKey: 'teamId' });
     }
   }
   StadiumImage.init({
-    teamId: DataTypes.INTEGER,
-    imageUrl: DataTypes.STRING,
+    teamId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Teams',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE'
+    },
+    imageUrl: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
     source: DataTypes.STRING,
-    sortOrder: DataTypes.INTEGER
+    sortOrder: {
+      type: DataTypes.INTEGER,
+      defaultValue: 0
+    }
   }, {
     sequelize,
     modelName: 'StadiumImage',

--- a/models/team.js
+++ b/models/team.js
@@ -10,12 +10,34 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-      // define association here
+      Team.belongsTo(models.League, { foreignKey: 'leagueId' });
+      Team.hasMany(models.StadiumImage, { foreignKey: 'teamId' });
+      Team.belongsToMany(models.Player, {
+        through: models.SquadMembership,
+        foreignKey: 'teamId',
+        otherKey: 'playerId'
+      });
+      Team.belongsToMany(models.User, {
+        through: models.Favorite,
+        foreignKey: 'teamId',
+        otherKey: 'userId'
+      });
     }
   }
   Team.init({
-    leagueId: DataTypes.INTEGER,
-    name: DataTypes.STRING,
+    leagueId: {
+      type: DataTypes.INTEGER,
+      references: {
+        model: 'Leagues',
+        key: 'id'
+      },
+      onUpdate: 'CASCADE',
+      onDelete: 'SET NULL'
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
     shortName: DataTypes.STRING,
     badgeUrl: DataTypes.STRING,
     logoUrl: DataTypes.STRING,
@@ -24,7 +46,11 @@ module.exports = (sequelize, DataTypes) => {
     stadiumName: DataTypes.STRING,
     stadiumCity: DataTypes.STRING,
     stadiumCapacity: DataTypes.INTEGER,
-    externalRef: DataTypes.STRING,
+    externalRef: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true
+    },
     description: DataTypes.TEXT,
     lastSyncedAt: DataTypes.DATE
   }, {

--- a/models/user.js
+++ b/models/user.js
@@ -10,14 +10,25 @@ module.exports = (sequelize, DataTypes) => {
      * The `models/index` file will call this method automatically.
      */
     static associate(models) {
-      // define association here
+      User.belongsToMany(models.Team, {
+        through: models.Favorite,
+        foreignKey: 'userId',
+        otherKey: 'teamId'
+      });
     }
   }
   User.init({
-    email: DataTypes.STRING,
+    email: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true
+    },
     passwordHash: DataTypes.STRING,
     displayName: DataTypes.STRING,
-    googleSub: DataTypes.STRING
+    googleSub: {
+      type: DataTypes.STRING,
+      unique: true
+    }
   }, {
     sequelize,
     modelName: 'User',


### PR DESCRIPTION
## Summary
- add migrations for leagues, teams, players, squad memberships, stadium images, users and favorites with foreign keys and indexes
- implement matching Sequelize models and associations for teams, players, leagues, users and favorites

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6507d7dc832a937074cacf682076