### PR TITLE
Add script to sync select leagues from TheSportsDB

### DIFF
--- a/scripts/syncLeagues.js
+++ b/scripts/syncLeagues.js
@@ -1,0 +1,23 @@
+const { League, sequelize } = require('../models');
+const { getTargetLeagues } = require('../services/sportsDBService');
+
+async function syncLeagues() {
+  try {
+    const leagues = await getTargetLeagues();
+    const mapped = leagues.map(l => ({
+      name: l.strLeague,
+      country: l.strCountry,
+      externalRef: l.idLeague,
+      logoUrl: l.strBadge || l.strLogo || null
+    }));
+    await League.bulkCreate(mapped, { ignoreDuplicates: true });
+    console.log(`Synced ${mapped.length} leagues`);
+  } catch (err) {
+    console.error('Failed to sync leagues', err.message);
+    throw err;
+  } finally {
+    await sequelize.close();
+  }
+}
+
+syncLeagues();

--- a/services/sportsDBService.js
+++ b/services/sportsDBService.js
@@ -1,0 +1,19 @@
+const BASE_URL = 'https://www.thesportsdb.com/api/v1/json/3';
+
+async function getTargetLeagues() {
+  const res = await fetch(`${BASE_URL}/search_all_leagues.php?s=Soccer`);
+  const data = await res.json();
+  const leagues = data.countrys || [];
+  const targetNames = [
+    'English Premier League',
+    'Spanish La Liga',
+    'Italian Serie A',
+    'German Bundesliga',
+    'French Ligue 1',
+    'Major League Soccer',
+    'Saudi Pro League'
+  ];
+  return leagues.filter(l => targetNames.includes(l.strLeague));
+}
+
+module.exports = { getTargetLeagues };


### PR DESCRIPTION
## Summary
- add service to fetch specific leagues from TheSportsDB API
- add script to store those leagues in the database

## Testing
- `npm test` (fails: Error: no test specified)
- `node scripts/syncLeagues.js` (fails: fetch failed)


------
https://chatgpt.com/codex/tasks/task_e_68bc67b024c4832a85744e9512ffe38c